### PR TITLE
Improve UI compatbility with dark color schemes

### DIFF
--- a/qtmips_gui/coreview.cpp
+++ b/qtmips_gui/coreview.cpp
@@ -234,6 +234,8 @@ CoreViewScene::CoreViewScene(machine::QtMipsMachine *machine) : QGraphicsScene()
     new_label("Stalls", 570, SC_HEIGHT - 14);
     NEW_V(630, SC_HEIGHT - 9, stall_c_value, false, 10, 0, 10, ' ', false);
 
+    setBackgroundBrush(QBrush(Qt::white));
+
     connect(regs, SIGNAL(open_registers()), this, SIGNAL(request_registers()));
     connect(mem_program, SIGNAL(open_mem()), this, SIGNAL(request_program_memory()));
     connect(mem_data, SIGNAL(open_mem()), this, SIGNAL(request_data_memory()));

--- a/qtmips_gui/coreview/adder.cpp
+++ b/qtmips_gui/coreview/adder.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "adder.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -80,6 +81,11 @@ void Adder::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __at
         QPointF(DENT, HEIGHT / 2),
         QPointF(0, (HEIGHT / 2) - DENT)
     };
+
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawPolygon(poly, sizeof(poly) / sizeof(QPointF));
 }
 

--- a/qtmips_gui/coreview/alu.cpp
+++ b/qtmips_gui/coreview/alu.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "alu.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -79,6 +80,11 @@ void coreview::Alu::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
         QPointF(DENT, HEIGHT / 2),
         QPointF(0, (HEIGHT / 2) - DENT)
     };
+
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawPolygon(poly, sizeof(poly) / sizeof(QPointF));
 }
 

--- a/qtmips_gui/coreview/and.cpp
+++ b/qtmips_gui/coreview/and.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "and.h"
+#include "coreview_colors.h"
 #include <cmath>
 
 using namespace coreview;
@@ -63,6 +64,10 @@ QRectF And::boundingRect() const {
 }
 
 void And::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute__((unused)), QWidget *widget __attribute__((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     qreal size = GAP * connectors.size();
     painter->drawLine(0, 0, 0, size);
     painter->drawLine(0, 0, size/2, 0);

--- a/qtmips_gui/coreview/coreview_colors.h
+++ b/qtmips_gui/coreview/coreview_colors.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*******************************************************************************
+ * QtMips - MIPS 32-bit Architecture Subset Simulator
+ *
+ * Implemented to support following courses:
+ *
+ *   B35APO - Computer Architectures
+ *   https://cw.fel.cvut.cz/wiki/courses/b35apo
+ *
+ *   B4M35PAP - Advanced Computer Architectures
+ *   https://cw.fel.cvut.cz/wiki/courses/b4m35pap/start
+ *
+ * Copyright (c) 2017-2019 Karel Koci<cynerd@email.cz>
+ * Copyright (c) 2019      Pavel Pisa <pisa@cmp.felk.cvut.cz>
+ *
+ * Faculty of Electrical Engineering (http://www.fel.cvut.cz)
+ * Czech Technical University        (http://www.cvut.cz/)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ *
+ ******************************************************************************/
+
+#ifndef COREVIEW_COLORS_H
+#define COREVIEW_COLORS_H
+
+#include <QColor>
+
+static const QColor BLOCK_OUTLINE_COLOR(85, 85, 85);
+
+#endif // COREVIEW_COLORS_H

--- a/qtmips_gui/coreview/latch.cpp
+++ b/qtmips_gui/coreview/latch.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "latch.h"
+#include "coreview_colors.h"
 #include <cmath>
 
 using namespace coreview;
@@ -76,6 +77,10 @@ QRectF Latch::boundingRect() const {
 }
 
 void Latch::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute__((unused)), QWidget *widget __attribute__((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawRect(0, 0, WIDTH, height);
     // Now tick rectangle
     const QPointF tickPolygon[] = {

--- a/qtmips_gui/coreview/logicblock.cpp
+++ b/qtmips_gui/coreview/logicblock.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "logicblock.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -79,6 +80,10 @@ QRectF LogicBlock::boundingRect() const {
 }
 
 void LogicBlock::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute__((unused)), QWidget *widget __attribute__((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawRoundedRect(box, RADIUS, RADIUS);
 }
 

--- a/qtmips_gui/coreview/memory.cpp
+++ b/qtmips_gui/coreview/memory.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "memory.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -81,6 +82,10 @@ QRectF Memory::boundingRect() const {
 }
 
 void Memory::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute__((unused)), QWidget *widget __attribute__((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawRect(0, 0, WIDTH, HEIGHT);
     if (cache)
         painter->drawLine(0, CACHE_HEIGHT, WIDTH, CACHE_HEIGHT);

--- a/qtmips_gui/coreview/programcounter.cpp
+++ b/qtmips_gui/coreview/programcounter.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "programcounter.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -75,6 +76,10 @@ QRectF ProgramCounter::boundingRect() const {
 }
 
 void ProgramCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute__((unused)), QWidget *widget __attribute__((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawRect(0, 0, WIDTH, HEIGHT);
 }
 

--- a/qtmips_gui/coreview/registers.cpp
+++ b/qtmips_gui/coreview/registers.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "registers.h"
+#include "coreview_colors.h"
 #include "fontsize.h"
 #include <cmath>
 
@@ -81,6 +82,10 @@ QRectF Registers::boundingRect() const {
 }
 
 void Registers::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __attribute((unused)), QWidget *widget __attribute((unused))) {
+    QPen pen = painter->pen();
+    pen.setColor(BLOCK_OUTLINE_COLOR);
+    painter->setPen(pen);
+
     painter->drawRect(0, 0, WIDTH, HEIGHT);
 }
 

--- a/qtmips_gui/coreview/value.cpp
+++ b/qtmips_gui/coreview/value.cpp
@@ -34,6 +34,7 @@
  ******************************************************************************/
 
 #include "value.h"
+#include "coreview_colors.h"
 #include "../fontsize.h"
 
 using namespace coreview;
@@ -73,6 +74,8 @@ void Value::paint(QPainter *painter, const QStyleOptionGraphicsItem *option __at
     painter->setBackgroundMode(Qt::OpaqueMode);
     if (!frame)
         painter->setPen(QColor(Qt::white));
+    else
+        painter->setPen(QColor(BLOCK_OUTLINE_COLOR));
     painter->drawRect(rect);
     painter->setPen(QColor(Qt::black));
     painter->setBackgroundMode(Qt::TransparentMode);

--- a/qtmips_gui/registersdock.cpp
+++ b/qtmips_gui/registersdock.cpp
@@ -71,6 +71,8 @@ static const QString labels[] = {
 };
 
 RegistersDock::RegistersDock(QWidget *parent) : QDockWidget(parent) {
+    static const QColor defaultTextColor(0, 0, 0);
+
     scrollarea = new QScrollArea(this);
     scrollarea->setWidgetResizable(true);
     widg = new StaticTable(scrollarea);
@@ -78,12 +80,18 @@ RegistersDock::RegistersDock(QWidget *parent) : QDockWidget(parent) {
     hi_highlighted = false;
     lo_highlighted = false;
 
+    pal_normal = palette();
+    pal_normal.setColor(QPalette::WindowText, defaultTextColor);
+
 #define INIT(X, LABEL) do{ \
         X = new QLabel("0x00000000", widg); \
         X->setFixedSize(X->sizeHint()); \
         X->setText(""); \
+	X->setPalette(pal_normal); \
         X->setTextInteractionFlags(Qt::TextSelectableByMouse); \
-        widg->addRow({new QLabel(LABEL, widg), X}); \
+	QLabel *l = new QLabel(LABEL, widg); \
+	l->setPalette(pal_normal); \
+        widg->addRow({l, X}); \
     } while(false)
 
     for (int i = 0; i < 32; i++)
@@ -98,10 +106,8 @@ RegistersDock::RegistersDock(QWidget *parent) : QDockWidget(parent) {
     setObjectName("Registers");
     setWindowTitle("Registers");
 
-    pal_normal = QPalette(gp[0]->palette());
-    pal_updated = QPalette(gp[0]->palette());
-    pal_read = QPalette(gp[0]->palette());
-    pal_normal.setColor(QPalette::WindowText, QColor(0, 0, 0));
+    pal_updated = pal_normal;
+    pal_read = pal_normal;
     pal_updated.setColor(QPalette::WindowText, QColor(240, 0, 0));
     pal_read.setColor(QPalette::WindowText, QColor(0, 0, 240));
 }

--- a/qtmips_gui/srceditor.cpp
+++ b/qtmips_gui/srceditor.cpp
@@ -35,6 +35,7 @@
 
 #include <QFile>
 #include <QFileInfo>
+#include <QPalette>
 #include <QTextDocumentWriter>
 #include <QTextCursor>
 #include <QTextBlock>
@@ -52,6 +53,12 @@ void SrcEditor::setup_common() {
     setFont(font);
     tname = "Unknown";
     highlighter = new HighlighterAsm(document());
+
+    QPalette p = palette();
+    p.setColor(QPalette::Active, QPalette::Base, Qt::white);
+    p.setColor(QPalette::Inactive, QPalette::Base, Qt::white);
+    p.setColor(QPalette::Disabled, QPalette::Base, Qt::white);
+    setPalette(p);
 }
 
 SrcEditor::SrcEditor(QWidget *parent) : Super(parent) {

--- a/qtmips_gui/srceditor.cpp
+++ b/qtmips_gui/srceditor.cpp
@@ -59,6 +59,8 @@ void SrcEditor::setup_common() {
     p.setColor(QPalette::Inactive, QPalette::Base, Qt::white);
     p.setColor(QPalette::Disabled, QPalette::Base, Qt::white);
     setPalette(p);
+
+    setTextColor(Qt::black);
 }
 
 SrcEditor::SrcEditor(QWidget *parent) : Super(parent) {


### PR DESCRIPTION
Those of us night people who use dark color schemes may find some of the visual elements difficult to read because the colors used by QtMips UI assume a white color scheme. See the following images for some examples:

[OK (Core view) - white color scheme](https://devoid-pointer.net/qtmips_dark/breeze_light.png)
[OK (Source editor) - white color scheme](https://devoid-pointer.net/qtmips_dark/breeze_light_code.png)
[Not OK (Core view) - Dark color scheme](https://devoid-pointer.net/qtmips_dark/breeze_dark.png)
[Not OK (Source editor) - Dark color scheme](https://devoid-pointer.net/qtmips_dark/breeze_dark_code.png)

This small patch series forces the problematic palette colors to shades that are compatible with a white color scheme instead of inheriting them from the system palette.

[Fixed (Core view) - Dark color scheme](https://devoid-pointer.net/qtmips_dark/breeze_dark_fixed.png)
[Fixed (Source editor) - Dark color scheme](https://devoid-pointer.net/qtmips_dark/breeze_dark_code_fixed.png)
