### PR TITLE
add support for qt6

### DIFF
--- a/qtmips_asm/fixmatheval.cpp
+++ b/qtmips_asm/fixmatheval.cpp
@@ -219,7 +219,7 @@ bool FmeExpression::parse(const QString &expression, QString &error) {
     bool is_unary = true;
     QString optxtx;
     for (i = 0; true; i++) {
-        QChar ch = 0;
+        QChar ch {};
         if (i < expression.size()) {
             ch = expression.at(i);
         }

--- a/qtmips_asm/simpleasm.cpp
+++ b/qtmips_asm/simpleasm.cpp
@@ -528,36 +528,56 @@ bool SimpleAsm::process_line(
             }
             s = s.mid(1, s.count() - 2);
             for (pos = 0; pos < s.count(); pos++) {
-                QChar ch = s.at(pos);
-                if (ch == '\\') {
-                    ch = '\0';
-                    if (pos + 1 < s.count()) {
-                        switch (s.at(++pos).toLatin1()) {
-                        case '\\': ch = '\\'; break;
-                        case '0': ch = '\0'; break;
-                        case 'r': ch = '\r'; break;
-                        case 'n': ch = '\n'; break;
-                        case 't': ch = '\t'; break;
-                        case 'b': ch = '\b'; break;
-                        case '"': ch = '"'; break;
-                        default: ch = '\0';
-                        }
-                    }
-                    if (ch == '\0') {
-                        error = "ascii - incorrect escape sequence";
-                        emit report_message(
-                            messagetype::MSG_ERROR, filename, line_number, 0,
-                            error, "");
+                // target byte is in ASCII encoding
+                uint8_t target_byte = 0x00;
+
+                QChar host_char = s.at(pos);
+                if (host_char == '\\') {
+                    // if the host encoding recognizes this as a backslash (escape char)
+
+                    // handle end of the string check
+                    if (pos + 1 >= s.count()) {
+                        error = "ascii - invalid escape sequence at the end of the string";
+                        emit report_message(messagetype::MSG_ERROR, filename, line_number, 0, error, "");
                         error_occured = true;
                         if (error_ptr != nullptr) {
                             *error_ptr = error;
                         }
                         return false;
                     }
+
+                    // compare the host_char in host encoding but emit byte in ASCII encoding
+                    host_char = s.at(++pos);
+                    if (host_char == '0') {
+                        target_byte = 0x00;
+                    } else if (host_char == 'b') {
+                        target_byte = 0x08;
+                    } else if (host_char == 't') {
+                        target_byte = 0x09;
+                    } else if (host_char == 'n') {
+                        target_byte = 0x0A;
+                    } else if (host_char == 'r') {
+                        target_byte = 0x0D;
+                    } else if (host_char == '"') {
+                        target_byte = 0x22;
+                    }  else if (host_char == '\\') {
+                        target_byte = 0x5C;
+                    } else {
+                        error = QString("ascii - incorrect escape sequence '\\") + host_char + "'";
+                        emit report_message(messagetype::MSG_ERROR, filename, line_number, 0, error, "");
+                        error_occured = true;
+                        if (error_ptr != nullptr) {
+                            *error_ptr = error;
+                        }
+                        return false;
+                    }
+                } else {
+                    // otherwise convert it to ASCII and write it as-is
+                    target_byte = host_char.toLatin1();
                 }
+
                 if (!fatal_occured) {
-                    mem->write_u8(
-                        address, (uint8_t)ch.toLatin1(), ae::INTERNAL);
+                    mem->write_u8(address, target_byte, ae::INTERNAL);
                 }
                 address += 1;
             }

--- a/qtmips_asm/simpleasm.cpp
+++ b/qtmips_asm/simpleasm.cpp
@@ -530,17 +530,17 @@ bool SimpleAsm::process_line(
             for (pos = 0; pos < s.count(); pos++) {
                 QChar ch = s.at(pos);
                 if (ch == '\\') {
-                    ch = 0;
+                    ch = '\0';
                     if (pos + 1 < s.count()) {
                         switch (s.at(++pos).toLatin1()) {
                         case '\\': ch = '\\'; break;
-                        case '0': ch = 0x00; break;
-                        case 'r': ch = 0x0d; break;
-                        case 'n': ch = 0x0a; break;
-                        case 't': ch = 0x09; break;
-                        case 'b': ch = 0x08; break;
+                        case '0': ch = '\0'; break;
+                        case 'r': ch = '\r'; break;
+                        case 'n': ch = '\n'; break;
+                        case 't': ch = '\t'; break;
+                        case 'b': ch = '\b'; break;
                         case '"': ch = '"'; break;
-                        default: ch = 0;
+                        default: ch = '\0';
                         }
                     }
                     if (ch == '\0') {

--- a/qtmips_gui/coreview/connection.cpp
+++ b/qtmips_gui/coreview/connection.cpp
@@ -180,7 +180,7 @@ void Connection::recalc_line() {
 
 bool Connection::recalc_line_add_point(const QLineF &l1, const QLineF &l2) {
     QPointF intersec;
-    if (l1.intersect(l2, &intersec) == QLineF::NoIntersection) {
+    if (l1.intersects(l2, &intersec) == QLineF::NoIntersection) {
         return false;
     }
     points.append(intersec);
@@ -224,7 +224,7 @@ static qreal cu_closest(const QLineF &l, const QPointF &p, QPointF *intersec) {
     QLineF nline = normal.translated(-normal.p1()).translated(p);
     // And now found intersection
     SANITY_ASSERT(
-        l.intersect(nline, intersec) != QLineF::NoIntersection,
+        l.intersects(nline, intersec) != QLineF::NoIntersection,
         "We are calculating intersection with normal vector and that should "
         "always have intersection");
     // Now check if that point belongs to given line

--- a/qtmips_gui/memorytableview.cpp
+++ b/qtmips_gui/memorytableview.cpp
@@ -38,6 +38,7 @@
 #include "hinttabledelegate.h"
 #include "memorymodel.h"
 
+#include <QtGlobal>
 #include <QApplication>
 #include <QClipboard>
 #include <QFontMetrics>
@@ -81,10 +82,18 @@ void MemoryTableView::adjustColumnCount() {
         QModelIndex idx;
         QFontMetrics fm(*m->getFont());
         idx = m->index(0, 0);
+        
+        QStyleOptionViewItem viewOpts;
+        #if QT_VERSION >= 0x060000
+            initViewItemOption(&viewOpts);
+        #else
+            viewOpts = viewOptions();
+        #endif
+
         // int width0_dh = itemDelegate(idx)->sizeHint(viewOptions(),
         // idx).get_width() + 2;
         int width0_dh
-            = delegate->sizeHintForText(viewOptions(), idx, "0x00000000").width()
+            = delegate->sizeHintForText(viewOpts, idx, "0x00000000").width()
               + 2;
         horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
         horizontalHeader()->resizeSection(0, width0_dh);
@@ -93,9 +102,9 @@ void MemoryTableView::adjustColumnCount() {
         QString t = "";
         t.fill(QChar('0'), m->cellSizeBytes() * 2);
         int width1_dh
-            = delegate->sizeHintForText(viewOptions(), idx, t).width() + 2;
-        if (width1_dh < fm.width("+99")) {
-            width1_dh = fm.width("+99");
+            = delegate->sizeHintForText(viewOpts, idx, t).width() + 2;
+        if (width1_dh < fm.horizontalAdvance("+99")) {
+            width1_dh = fm.horizontalAdvance("+99");
         }
         horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
         horizontalHeader()->resizeSection(1, width1_dh);

--- a/qtmips_gui/newdialog.cpp
+++ b/qtmips_gui/newdialog.cpp
@@ -321,7 +321,8 @@ void NewDialog::osemu_exception_stop_change(bool v) {
 
 void NewDialog::browse_osemu_fs_root() {
     QFileDialog osemu_fs_root_dialog(this);
-    osemu_fs_root_dialog.setFileMode(QFileDialog::DirectoryOnly);
+    osemu_fs_root_dialog.setFileMode(QFileDialog::Directory);
+    osemu_fs_root_dialog.setOption(QFileDialog::ShowDirsOnly, true);
     if (osemu_fs_root_dialog.exec()) {
         QString path = osemu_fs_root_dialog.selectedFiles()[0];
         ui->osemu_fs_root->setText(path);

--- a/qtmips_gui/programtableview.cpp
+++ b/qtmips_gui/programtableview.cpp
@@ -38,6 +38,7 @@
 #include "hinttabledelegate.h"
 #include "programmodel.h"
 
+#include <QtGlobal>
 #include <QApplication>
 #include <QClipboard>
 #include <QFontMetrics>
@@ -84,15 +85,22 @@ void ProgramTableView::adjustColumnCount() {
         return;
     }
 
+    QStyleOptionViewItem viewOpts;
+    #if QT_VERSION >= 0x060000
+        initViewItemOption(&viewOpts);
+    #else
+        viewOpts = viewOptions();
+    #endif
+
     idx = m->index(0, 0);
-    cwidth_dh = delegate->sizeHintForText(viewOptions(), idx, "Bp").width() + 2;
+    cwidth_dh = delegate->sizeHintForText(viewOpts, idx, "Bp").width() + 2;
     horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
     horizontalHeader()->resizeSection(0, cwidth_dh);
     totwidth = cwidth_dh;
 
     idx = m->index(0, 1);
     cwidth_dh
-        = delegate->sizeHintForText(viewOptions(), idx, "0x00000000").width()
+        = delegate->sizeHintForText(viewOpts, idx, "0x00000000").width()
           + 2;
     horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
     horizontalHeader()->resizeSection(1, cwidth_dh);
@@ -100,7 +108,7 @@ void ProgramTableView::adjustColumnCount() {
 
     idx = m->index(0, 2);
     cwidth_dh
-        = delegate->sizeHintForText(viewOptions(), idx, "00000000").width() + 2;
+        = delegate->sizeHintForText(viewOpts, idx, "00000000").width() + 2;
     horizontalHeader()->setSectionResizeMode(2, QHeaderView::Fixed);
     horizontalHeader()->resizeSection(2, cwidth_dh);
     totwidth += cwidth_dh;
@@ -109,7 +117,7 @@ void ProgramTableView::adjustColumnCount() {
     idx = m->index(0, 3);
     totwidth
         += delegate
-               ->sizeHintForText(viewOptions(), idx, "BEQ $18, $17, 0x80020058")
+               ->sizeHintForText(viewOpts, idx, "BEQ $18, $17, 0x80020058")
                .width()
            + 2;
     totwidth += verticalHeader()->width();

--- a/qtmips_gui/statictable.cpp
+++ b/qtmips_gui/statictable.cpp
@@ -98,7 +98,11 @@ QSize StaticTableLayout::minimumSize() const {
         }
         cch_minSize.size = cch_minSize.size.expandedTo(ss - QSize(shspace, 0));
     }
-    cch_minSize.size += QSize(2 * margin(), 2 * margin());
+
+    int left, top, right, bottom;
+    getContentsMargins(&left, &top, &right, &bottom);
+    cch_minSize.size += QSize(left + right, top + bottom);
+
     return cch_minSize.size;
 }
 

--- a/qtmips_machine/alu.cpp
+++ b/qtmips_machine/alu.cpp
@@ -35,6 +35,8 @@
 
 #include "alu.h"
 
+#include <climits>
+
 #include "qtmipsexception.h"
 #include "utils.h"
 

--- a/qtmips_machine/cop0state.cpp
+++ b/qtmips_machine/cop0state.cpp
@@ -134,28 +134,28 @@ void Cop0State::setup_core(Core *core) {
 
 uint32_t Cop0State::read_cop0reg(uint8_t rd, uint8_t sel) const {
     SANITY_ASSERT(
-        rd < 32, QString("Trying to read from cop0 register ") + QString(rd)
-                     + ',' + QString(sel));
+        rd < 32, QString("Trying to read from cop0 register ") + QString::number(rd)
+                     + ',' + QString::number(sel));
     SANITY_ASSERT(
-        sel < 8, QString("Trying to read from cop0 register ") + QString(rd)
-                     + ',' + QString(sel));
+        sel < 8, QString("Trying to read from cop0 register ") + QString::number(rd)
+                     + ',' + QString::number(sel));
     enum Cop0Registers reg = cop0reg_map[rd][sel];
     SANITY_ASSERT(
-        reg != 0, QString("Cop0 register ") + QString(rd) + ',' + QString(sel)
+        reg != 0, QString("Cop0 register ") + QString::number(rd) + ',' + QString::number(sel)
                       + "unsupported");
     return read_cop0reg(reg);
 }
 
 void Cop0State::write_cop0reg(uint8_t rd, uint8_t sel, RegisterValue value) {
     SANITY_ASSERT(
-        rd < 32, QString("Trying to write to cop0 register ") + QString(rd)
-                     + ',' + QString(sel));
+        rd < 32, QString("Trying to write to cop0 register ") + QString::number(rd)
+                     + ',' + QString::number(sel));
     SANITY_ASSERT(
-        sel < 8, QString("Trying to write to cop0 register ") + QString(rd)
-                     + ',' + QString(sel));
+        sel < 8, QString("Trying to write to cop0 register ") + QString::number(rd)
+                     + ',' + QString::number(sel));
     enum Cop0Registers reg = cop0reg_map[rd][sel];
     SANITY_ASSERT(
-        reg != 0, QString("Cop0 register ") + QString(rd) + ',' + QString(sel)
+        reg != 0, QString("Cop0 register ") + QString::number(rd) + ',' + QString::number(sel)
                       + "unsupported");
     write_cop0reg(reg, value);
 }
@@ -163,14 +163,14 @@ void Cop0State::write_cop0reg(uint8_t rd, uint8_t sel, RegisterValue value) {
 uint32_t Cop0State::read_cop0reg(enum Cop0Registers reg) const {
     SANITY_ASSERT(
         reg != Unsupported && reg < COP0REGS_CNT,
-        QString("Trying to read from cop0 register ") + QString(reg));
+        QString("Trying to read from cop0 register ") + QString::number(reg));
     return (this->*cop0reg_desc[reg].reg_read)(reg);
 }
 
 void Cop0State::write_cop0reg(enum Cop0Registers reg, RegisterValue value) {
     SANITY_ASSERT(
         reg != Unsupported && reg < COP0REGS_CNT,
-        QString("Trying to write to cop0 register ") + QString(reg));
+        QString("Trying to write to cop0 register ") + QString::number(reg));
     (this->*cop0reg_desc[reg].reg_write)(reg, value.as_u32());
 }
 

--- a/qtmips_machine/memory/backend/memory.cpp
+++ b/qtmips_machine/memory/backend/memory.cpp
@@ -54,11 +54,13 @@ MemorySection::MemorySection(const MemorySection &other)
     , dt(other.dt) {}
 
 WriteResult MemorySection::write(
-    Offset destination,
+    Offset dst_offset,
     const void *source,
     size_t size,
     WriteOptions options) {
     UNUSED(options)
+
+    size_t destination = static_cast<size_t>(dst_offset);
 
     if (destination >= length()) {
         throw QTMIPS_EXCEPTION(
@@ -81,10 +83,12 @@ WriteResult MemorySection::write(
 
 ReadResult MemorySection::read(
     void *destination,
-    Offset source,
+    Offset src_offset,
     size_t size,
     ReadOptions options) const {
     UNUSED(options)
+
+    size_t source = static_cast<size_t>(src_offset);
 
     size = std::min(source + size, length()) - source;
 

--- a/qtmips_machine/memory/backend/serialport.cpp
+++ b/qtmips_machine/memory/backend/serialport.cpp
@@ -170,7 +170,7 @@ uint32_t SerialPort::read_reg(Offset source, AccessEffects type) const {
     case SERP_TX_ST_REG_o: value = tx_st_reg | SERP_TX_ST_REG_READY_m; break;
     default:
         printf(
-            "WARNING: Serial port - read out of range (at 0x%ld).\n", source);
+            "WARNING: Serial port - read out of range (at 0x%lu).\n", source);
         break;
     }
 
@@ -201,7 +201,7 @@ bool SerialPort::write_reg(Offset destination, uint32_t value) {
             return true;
         default:
             printf(
-                "WARNING: Serial port - write out of range (at 0x%ld).\n",
+                "WARNING: Serial port - write out of range (at 0x%lu).\n",
                 destination);
             return false;
         }

--- a/qtmips_machine/registers.h
+++ b/qtmips_machine/registers.h
@@ -70,7 +70,7 @@ inline RegisterId::RegisterId(uint8_t value) : data(value) {
     SANITY_ASSERT(
         data < REGISTER_COUNT,
         QString("Trying to create register id for out-of-bounds register ")
-            + QString(data));
+            + QString::number(data));
 };
 
 inline RegisterId operator"" _reg(unsigned long long value) {


### PR DESCRIPTION
the exact changes are:
* Assigning an int to QChar fails to compile due to type ambiguity. Changed occurences to either assign uchar or to use the default constructor. 
* [qt5.14] QLineF::intersect replaced by QLineF::intersects
* [qt6.0] QTableView::viewOptions replaced by QTableView::initViewItemOption with a different interface - covered by preprocessor #if check
* [qt5.11] QFontMetrics::width replaced by QFontMetrics::horizontalAdvance
* [N/A] QFileDialog::setFileMode(QFileDialog::DirectoryOnly) replaced by QFileDialog::setFileMode(QFileDialog::Directory) and QFileDialog::setOption(QFileDialog::ShowDirsOnly, true)
* [qt4.3] QLayout::margin replaced by QLayout::getContentsMargins
* [N/A] Multiple calls to QString(int) replaced by QString::number(int) (I belive this was a bug in the original implementation and was uncovered thanks to the update)
	- This is probably the same problem as the one that popped up in the first change (QChar), not sure why it didn't complain sooner
* There is a problem with Offset type not being the same size as size_t on macos, so a static_cast<size_t>(Offset) was added to fix the warning

Everything still builds with qt5, most of the changes were replacing functions which are already deprecated in qt5 and have defined alternatives.

These changes are sufficient to build on Linux with qt6, however, to build macos I've had to bump the `QMAKE_MACOSX_DEPLOYMENT_TARGET` found in build-macos.sh from 10.14 to at least 10.15.

Also I've had to manually copy the elf.h header from another libelf since the one provided by brew does not contain this header (it is not maintained anymore, but I'm not sure why the header is missing in the first place). This means that even with these changes the project won't build for macos with qt6 in the environment described in azure-pipelines.yml file.

closes #13 